### PR TITLE
Enable data-url for profile- and channel pictures

### DIFF
--- a/src/views/channel/components/channel-header/index.tsx
+++ b/src/views/channel/components/channel-header/index.tsx
@@ -17,7 +17,7 @@ const ChannelHeader = () => {
         return null;
     }
 
-    const hasPicture = channel.picture.startsWith('https://');
+    const hasPicture = channel.picture.match(/^(https:|data:)/);
 
     return <AppContentHeaderBase>
         {hasPicture && (

--- a/src/views/components/avatar/index.tsx
+++ b/src/views/components/avatar/index.tsx
@@ -9,7 +9,7 @@ const Avatar = (props: { src?: string, seed: string, size: number, rounded?: boo
     const {src, seed, size, rounded} = props;
     const theme = useTheme();
     const avatar = useMemo(() => {
-        if (src && src.startsWith('https://')) {
+        if (src && src.match(/^(https:|data:)/)) {
             return src;
         }
 

--- a/src/views/components/channel-card/index.tsx
+++ b/src/views/components/channel-card/index.tsx
@@ -18,7 +18,7 @@ const ChannelCard = (props: { channel: Channel, onJoin: () => void }) => {
     const [keys] = useAtom(keysAtom);
     const [leftChannelList] = useAtom(leftChannelListAtom);
 
-    const hasPicture = channel.picture.startsWith('https://');
+    const hasPicture = channel.picture.match(/^(https:|data:)/);
     const left = leftChannelList.includes(channel.id);
 
     const join = () => onJoin();

--- a/src/views/components/metadata-form/index.tsx
+++ b/src/views/components/metadata-form/index.tsx
@@ -60,7 +60,7 @@ const MetadataForm = (props: {
         const scheme = Joi.object({
             name: Joi.string().required(),
             about: Joi.string().empty(''),
-            picture: Joi.string().uri({scheme: 'https', allowRelative: false}).empty(''),
+            picture: Joi.string().uri({scheme: [/https?|data/], allowRelative: false}).empty(''),
         }).messages({
             'string.uriCustomScheme': t('Picture must be a valid uri with a scheme matching the https pattern')
         });


### PR DESCRIPTION
Besides https:// we allow data: in the profile or channel picture field and display them as logo.

With the picture stored into the nostr-event, we don't need an external server to serve this logo-kind little picture.

That is one less GET, one less access_log we are filling.